### PR TITLE
adding cloudflare adaptor to prevent infinite loop on HTTPS

### DIFF
--- a/index.php
+++ b/index.php
@@ -11,6 +11,23 @@
 define('SHJ_VERSION','1.4');
 
 /**
+ * Cloudflare adaptor.
+ * This module will help the Framework know what actually happends
+ * on the client. This will manipulate the PHP's $_SERVER var for
+ * detecting IP, SCHEME, and other Usefull tools.
+ *
+*/
+if(isset($_SERVER['HTTP_CF_CONNECTING_IP']) && isset($_SERVER['HTTP_CF_RAY'])){
+	$_SERVER['REMOTE_ADDR'] = $_SERVER['HTTP_CF_CONNECTING_IP'];
+	$_SERVER['HTTP_X_REAL_IP'] = $_SERVER['HTTP_CF_CONNECTING_IP'];
+	if(isset($_SERVER['HTTP_CF_VISITOR']) || !isset($_SERVER['REQUEST_SCHEME'])){
+	  $_SERVER['REQUEST_SCHEME'] = (isset($_SERVER['HTTP_CF_VISITOR']) &&
+				   strpos($_SERVER['HTTP_CF_VISITOR'],'https')>-1)?'https':'http';
+	  $_SERVER['HTTPS'] = ($_SERVER['REQUEST_SCHEME']=="https")?"on":null;
+	}
+  }
+
+/**
  * CodeIgniter
  *
  * An open source application development framework for PHP 5.2.4 or newer


### PR DESCRIPTION
Adding Cloudflare adaptor.

on Lab we used Cloudflare to mask IP and firewalling things. This will make sure that we will not get infinite redirects.